### PR TITLE
Add NSenter tunnel that allows to enter in any linux namespace container

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,8 @@ remote hosts over SSH.
 Naturally this is agentless and nothing needs to be installed on the remote
 host except Python and an SSH agent.
 
-It also has support for executing code in Docker containers.
+It also has support for executing code in Docker or any linux namespaces based
+containers.
 
 It's perhaps best compared to Ansible or Fabric, but has some clever transport
 magic which means it's very easy to develop with: you just write Python

--- a/chopsticks/__init__.py
+++ b/chopsticks/__init__.py
@@ -12,3 +12,15 @@ DEPTH_LIMIT = getattr(sys, '_chopsticks_depthlimit', 2)
 # This option can also be set via the CHOPSTICKS_ALLOW_SITE_IMPORTS environment
 # variable.
 allow_site_imports = False
+
+
+def get_current_function():
+    """Return the callable currently being executed by chopsticks on this remote.
+
+    Returns None if called outside of a chopsticks remote call or outside the
+    current thread's active call.
+    """
+    tl = getattr(sys, '_chopsticks_current_func', None)
+    if tl is None:
+        return None
+    return getattr(tl, 'value', None)

--- a/chopsticks/__init__.py
+++ b/chopsticks/__init__.py
@@ -1,7 +1,7 @@
 import sys
 
-__version__ = '1.0'
-__versioninfo__ = (1, 0)
+__version__ = '1.0.1'
+__versioninfo__ = (1, 0, 1)
 
 DEPTH_LIMIT = getattr(sys, '_chopsticks_depthlimit', 2)
 

--- a/chopsticks/__init__.py
+++ b/chopsticks/__init__.py
@@ -4,3 +4,11 @@ __version__ = '1.0'
 __versioninfo__ = (1, 0)
 
 DEPTH_LIMIT = getattr(sys, '_chopsticks_depthlimit', 2)
+
+# Set `chopsticks.allow_site_imports` to True to allow the remote Python to
+# import from its own site-packages. This basically removes -sS flags from the
+# remote Python invocation).
+#
+# This option can also be set via the CHOPSTICKS_ALLOW_SITE_IMPORTS environment
+# variable.
+allow_site_imports = False

--- a/chopsticks/__init__.py
+++ b/chopsticks/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __versioninfo__ = (1, 0, 1)
 
 DEPTH_LIMIT = getattr(sys, '_chopsticks_depthlimit', 2)

--- a/chopsticks/__init__.py
+++ b/chopsticks/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 __versioninfo__ = (1, 0, 1)
 
 DEPTH_LIMIT = getattr(sys, '_chopsticks_depthlimit', 2)

--- a/chopsticks/__init__.py
+++ b/chopsticks/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 __versioninfo__ = (1, 0, 1)
 
 DEPTH_LIMIT = getattr(sys, '_chopsticks_depthlimit', 2)

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import logging
 import sys
 sys.path = [p for p in sys.path if p.startswith('/')]
 __name__ = '__bubble__'
@@ -330,11 +331,32 @@ def handle_end_put(req_id, sha1sum):
     )
 
 
-def handle_start(req_id, host, path, depthlimit):
+class TunnelHandler(logging.Handler):
+    def emit(self, record):
+        log_entry = self.format(record)
+        debug(log_entry.strip())
+
+
+def handle_start(req_id, host, path, depthlimit, log_config):
     sys._chopsticks_host = force_str(host)
     sys._chopsticks_path = [force_str(p) for p in path]
     sys._chopsticks_depthlimit = depthlimit
     send_msg(OP_RET, req_id, {'ret': pickle.HIGHEST_PROTOCOL})
+
+    if log_config:
+        th = TunnelHandler()
+        level = log_config.get('level', logging.INFO)
+        if 'level' in log_config:
+            th.setLevel(level)
+            logging.root.setLevel(level)
+        if 'format' in log_config:
+            formatter = logging.Formatter(log_config['format'])
+            th.setFormatter(formatter)
+        logging.root.addHandler(th)
+
+    logging.getLogger("sh").setLevel(logging.ERROR)
+    logging.getLogger("requests").setLevel(logging.ERROR)
+    logging.getLogger("urllib3").setLevel(logging.ERROR)
 
 
 HEADER = struct.Struct('!LLbb')

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -257,9 +257,18 @@ def do_fetch(req_id, path):
     }
 
 
+_current_func = threading.local()
+sys._chopsticks_current_func = _current_func
+
+
 @transmit_errors
 def do_call(req_id, callable, args=(), kwargs={}):
-    ret = callable(*args, **kwargs)
+    prev = getattr(_current_func, 'value', None)
+    _current_func.value = callable
+    try:
+        ret = callable(*args, **kwargs)
+    finally:
+        _current_func.value = prev
     send_msg(
         OP_RET,
         req_id,

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -54,6 +54,7 @@ import traceback
 from base64 import b64decode
 import tempfile
 import codecs
+import site
 
 
 outqueue = Queue(maxsize=10)
@@ -61,9 +62,11 @@ tasks = Queue()
 done = object()
 
 running = True
+local_imports = False
 
 Imp = namedtuple('Imp', 'exists is_pkg file source')
 PREFIX = 'chopsticks://'
+SITE_PACKAGES = site.getsitepackages() + [site.getusersitepackages()]
 
 
 class Loader:
@@ -119,6 +122,10 @@ class Loader:
         return imp
 
     def find_module(self, fullname, path=None):
+        global local_imports
+        if local_imports:
+            return None
+
         try:
             self.get(fullname)
         except ImportError:

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -11,6 +11,13 @@ def debug(msg):
 
 # Reshuffle fds so that we can't break our transport by printing to stdout
 import os
+# Remove project source dirs from sys.path (e.g. from 'pip install -e .').
+# These are directories that contain a setup.py or pyproject.toml at the root,
+# which can shadow modules that should be fetched from the controller via OP_IMP.
+# Legitimate installed packages live in site-packages, not in source trees.
+sys.path = [p for p in sys.path
+            if not os.path.isfile(os.path.join(p, 'setup.py'))
+            and not os.path.isfile(os.path.join(p, 'pyproject.toml'))]
 # inpipe is defined in the bootstrap command line code in tunnel.py
 outfd = os.dup(1)
 outpipe = os.fdopen(outfd, 'wb', 0)

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -74,7 +74,7 @@ class Loader:
     # Imports that don't succeed after this amount of time will time out
     # This can help crash a remote process when the controller hangs, thus
     # breaking the deadlock.
-    TIMEOUT = 5  # seconds
+    TIMEOUT = 10  # seconds
 
     cache = {}
     lock = threading.RLock()

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -337,10 +337,11 @@ class TunnelHandler(logging.Handler):
         debug(log_entry.strip())
 
 
-def handle_start(req_id, host, path, depthlimit, log_config):
+def handle_start(req_id, host, path, depthlimit, log_config, allow_site_imports=False):
     sys._chopsticks_host = force_str(host)
     sys._chopsticks_path = [force_str(p) for p in path]
     sys._chopsticks_depthlimit = depthlimit
+    sys._chopsticks_allow_site_imports = allow_site_imports
     send_msg(OP_RET, req_id, {'ret': pickle.HIGHEST_PROTOCOL})
 
     if log_config:

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -43,10 +43,11 @@ else:
     from queue import Queue
     import pickle
     exec_ = getattr(__builtins__, 'exec')
-from imp import is_builtin
+from _imp import is_builtin
+from importlib import _bootstrap
 import time
 import struct
-import imp
+import types
 from collections import namedtuple
 import signal
 from hashlib import sha1
@@ -132,6 +133,16 @@ class Loader:
             return None
         return self
 
+    # Borrowed from Python3.11 deprecated behavior
+    def find_spec(self, fullname, path=None, target=None):
+        loader = self.find_module(fullname, path=path)
+        portions = []
+        if loader is not None:
+            return _bootstrap.spec_from_loader(fullname, loader)
+        spec = _bootstrap.ModuleSpec(fullname, None)
+        spec.submodule_search_locations = portions
+        return spec
+
     def load_module(self, fullname):
         m = self.get(fullname)
         modname = fullname
@@ -139,7 +150,7 @@ class Loader:
             # Special-case __main__ so as not to execute
             # if __name__ == '__main__' blocks
             modname = '__chopsticks_main__'
-        mod = sys.modules.setdefault(modname, imp.new_module(modname))
+        mod = sys.modules.setdefault(modname, types.ModuleType(modname))
         mod.__file__ = PREFIX + m.file
         mod.__loader__ = self
         if m.is_pkg:

--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -81,7 +81,7 @@ class Loader:
     # Imports that don't succeed after this amount of time will time out
     # This can help crash a remote process when the controller hangs, thus
     # breaking the deadlock.
-    TIMEOUT = 10  # seconds
+    TIMEOUT = 15  # seconds
 
     cache = {}
     lock = threading.RLock()
@@ -106,20 +106,18 @@ class Loader:
                 return self.cache[fullname]
             send_msg(OP_IMP, 0, {'imp': fullname})
             start = time.time()
-            self.ev.wait(timeout=self.TIMEOUT)
-            delay = time.time() - start
-            if delay >= self.TIMEOUT:
-                raise IOError(
-                    'Timed out after %ds waiting for import %r'
-                    % (self.TIMEOUT, fullname)
-                )
-            try:
-                imp = self.cache[fullname]
-            except KeyError:
-                raise IOError(
-                    'Did not find %s in %s' % (fullname, self.cache)
-                )
-        return imp
+            # Loop on ev.wait(): notifyAll() wakes ALL waiting threads on any
+            # module arrival, not just the one this thread needs.  Keep waiting
+            # until our specific module appears or the timeout expires.
+            while fullname not in self.cache:
+                remaining = self.TIMEOUT - (time.time() - start)
+                if remaining <= 0:
+                    raise IOError(
+                        'Timed out after %ds waiting for import %r'
+                        % (self.TIMEOUT, fullname)
+                    )
+                self.ev.wait(timeout=remaining)
+            return self.cache[fullname]
 
     def get(self, fullname):
         if isinstance(fullname, str) and is_builtin(fullname) != 0:

--- a/chopsticks/group.py
+++ b/chopsticks/group.py
@@ -119,6 +119,8 @@ class Group(SetOps):
         for t in tunnels:
             m = getattr(t, method)
             m(self.op.make_callback(t.host), *args, **kwargs)
+        if self.op.waiting == 0:
+            return GroupResult(self.op.results)
         try:
             return loop.run()
         except:

--- a/chopsticks/helpers.py
+++ b/chopsticks/helpers.py
@@ -26,3 +26,11 @@ def check_output(*args, **kwargs):
 def output_lines(*args, **kwargs):
     """Return the lines of output from the given command args."""
     return check_output(*args, **kwargs).splitlines()
+
+
+def get_inception_level():
+    try:
+        path = sys._chopsticks_path[:]
+    except AttributeError:
+        path = []
+    return len(path)

--- a/chopsticks/ioloop.py
+++ b/chopsticks/ioloop.py
@@ -302,4 +302,5 @@ class IOLoop:
             self.running = True
             while self.running and (self.read or self.write):
                 self.step()
+        self.stop(self.result)
         return self.result

--- a/chopsticks/ioloop.py
+++ b/chopsticks/ioloop.py
@@ -179,7 +179,11 @@ class StderrReader:
         self.loop.want_read(self.fd, self.on_data)
 
     def on_data(self):
-        chunk = os.read(self.fd, 512)
+        try:
+            chunk = os.read(self.fd, 512)
+        except OSError:
+            # fd was closed between select() and read() (e.g. tunnel closed)
+            chunk = None
         if not chunk:
             self._flush()
             return
@@ -280,9 +284,13 @@ class IOLoop:
             self.write.pop(x, None)
             reader = self.read.pop(x, None)
             if reader:
-                reader.errback('Error on stream')
+                errback = getattr(reader, 'errback', None)
+                if errback:
+                    errback('Error on stream')
         for r in rs:
-            self.read.pop(r)()
+            cb = self.read.pop(r, None)
+            if cb:
+                cb()
         for w in ws:
             self.write.pop(w)()
 
@@ -302,5 +310,6 @@ class IOLoop:
             self.running = True
             while self.running and (self.read or self.write):
                 self.step()
-        self.stop(self.result)
-        return self.result
+                result = self.result  # capture inside lock to avoid race with other threads
+        self.stop(result)
+        return result

--- a/chopsticks/ioloop.py
+++ b/chopsticks/ioloop.py
@@ -181,19 +181,24 @@ class StderrReader:
         self.fd = nonblocking_fd(fd)
         self.host = host
         self.buf = b''
+        # Initialize these before registering the reader.
+        self._reregister_lock = RLock()
+        self._stopped = False
         self.loop.want_read(self.fd, self.on_data)
 
     def on_data(self):
+        # Keep re-registration in sync with stop().
         try:
             chunk = os.read(self.fd, 512)
         except OSError:
-            # fd was closed between select() and read() (e.g. tunnel closed)
             chunk = None
         if not chunk:
             self._flush()
             return
         self.buf += chunk
-        self.loop.want_read(self.fd, self.on_data)
+        with self._reregister_lock:
+            if not self._stopped:
+                self.loop.want_read(self.fd, self.on_data)
         self._check()
 
     def println(self, l):
@@ -220,7 +225,9 @@ class StderrReader:
             self.buf = b''
 
     def stop(self):
-        self.loop.abort_read(self.fd)
+        with self._reregister_lock:
+            self._stopped = True
+            self.loop.abort_read(self.fd)
         self._flush()
 
     def __del__(self):

--- a/chopsticks/ioloop.py
+++ b/chopsticks/ioloop.py
@@ -4,8 +4,9 @@ import os
 import fcntl
 import struct
 import weakref
-from threading import RLock
+import select as _select_module
 from select import select
+from threading import RLock
 
 from .pencode import pencode, pdecode
 
@@ -277,10 +278,7 @@ class IOLoop:
         if self.running:
             self.os_write(self.breakw, b'x')
 
-    def step(self):
-        rfds = list(self.read) + [self.breakr]
-        wfds = list(self.write)
-        rs, ws, xs = select(rfds, wfds, rfds + wfds)
+    def _dispatch(self, rs, ws, xs):
         if self.breakr in rs:
             rs.remove(self.breakr)
             self.os_read(self.breakr, 512)
@@ -297,6 +295,54 @@ class IOLoop:
                 cb()
         for w in ws:
             self.write.pop(w)()
+
+    if hasattr(_select_module, 'poll'):
+        def step(self):
+            rfds = list(self.read) + [self.breakr]
+            wfds = list(self.write)
+            p = _select_module.poll()
+            fd_flags = {}
+            for fd in rfds:
+                fd_flags[fd] = fd_flags.get(fd, 0) | _select_module.POLLIN
+            for fd in wfds:
+                fd_flags[fd] = fd_flags.get(fd, 0) | _select_module.POLLOUT
+            for fd, flags in fd_flags.items():
+                p.register(fd, flags)
+            try:
+                events = p.poll(1000)
+            except OSError:
+                for fd in rfds + wfds:
+                    try:
+                        _select_module.select([fd], [], [], 0)
+                    except OSError:
+                        self.read.pop(fd, None)
+                        self.write.pop(fd, None)
+                return
+            rs, ws, xs = [], [], []
+            for fd, event in events:
+                if event & (_select_module.POLLERR | _select_module.POLLNVAL):
+                    xs.append(fd)
+                else:
+                    if event & (_select_module.POLLIN | _select_module.POLLHUP):
+                        rs.append(fd)
+                    if event & _select_module.POLLOUT:
+                        ws.append(fd)
+            self._dispatch(rs, ws, xs)
+    else:
+        def step(self):
+            rfds = list(self.read) + [self.breakr]
+            wfds = list(self.write)
+            try:
+                rs, ws, xs = select(rfds, wfds, rfds + wfds)
+            except OSError:
+                for fd in rfds + wfds:
+                    try:
+                        _select_module.select([fd], [], [], 0)
+                    except OSError:
+                        self.read.pop(fd, None)
+                        self.write.pop(fd, None)
+                return
+            self._dispatch(rs, ws, xs)
 
     def reader(self, *args, **kwargs):
         return MessageReader(self, *args, **kwargs)

--- a/chopsticks/ioloop.py
+++ b/chopsticks/ioloop.py
@@ -140,6 +140,10 @@ class MessageWriter:
             return
         try:
             written = os.write(self.fd, self.queue[0])
+        except BlockingIOError:
+            # Pipe full (EAGAIN) — leave data in queue and retry on next write event
+            self.loop.want_write(self.fd, self.on_write)
+            return
         except OSError:
             # TODO: handle errors properly
             import traceback
@@ -193,7 +197,7 @@ class StderrReader:
 
     def println(self, l):
         if not PY2:
-            l = l.decode('utf8')
+            l = l.decode('utf8', errors='replace')
         if sys.stderr.isatty():
             fmt = '\x1b[31m[{host}]\x1b[0m {l}'
         else:
@@ -308,6 +312,7 @@ class IOLoop:
         with self.lock:
             self.result = None
             self.running = True
+            result = None
             while self.running and (self.read or self.write):
                 self.step()
                 result = self.result  # capture inside lock to avoid race with other threads

--- a/chopsticks/serialise_main.py
+++ b/chopsticks/serialise_main.py
@@ -103,7 +103,7 @@ def serialise_func(f, seen=()):
             else:
                 subdeps = serialise_func(v, seen=seen + (f, v,))
                 vsource, _, _, vnames, vvars = subdeps
-                source += '\n\n' + vsource
+                source = vsource + '\n\n' + source
                 imported_names.update(vnames)
                 variables.update(vvars)
         else:

--- a/chopsticks/serialise_main.py
+++ b/chopsticks/serialise_main.py
@@ -29,10 +29,16 @@ def trace_globals(code):
     LOAD_GLOBAL = dis.opmap['LOAD_GLOBAL']
     LOAD_NAME = dis.opmap['LOAD_NAME']
     global_ops = (LOAD_GLOBAL, LOAD_NAME)
+
+    # In Python 3.11+, LOAD_GLOBAL arg encodes the index as arg >> 1
+    # (lowest bit indicates whether to push NULL before the value)
+    load_global_shift = sys.version_info >= (3, 11)
+
     loads = set()
     for op, arg in iter_opcodes(code.co_code):
         if op in global_ops:
-            loads.add(code.co_names[arg])
+            idx = arg >> 1 if (op == LOAD_GLOBAL and load_global_shift) else arg
+            loads.add(code.co_names[idx])
     for c in code.co_consts:
         if isinstance(c, types.CodeType):
             loads.update(trace_globals(c))

--- a/chopsticks/serialise_main.py
+++ b/chopsticks/serialise_main.py
@@ -77,7 +77,8 @@ def iter_opcodes(code):
     else:
         # More recent Python 3 has a function for this, though it is
         # not a public API.
-        for _, op, arg in unpack_opargs(code):
+        for item in unpack_opargs(code):
+            op, arg = item[-2], item[-1]
             yield (op, arg)
 
 

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import logging
+import contextlib
 import subprocess
 import sys
 import os
@@ -46,6 +47,33 @@ OP_PUT_END = 9
 OP_START = 10
 
 CHOPSTICKS_PREFIX = 'chopsticks://'
+
+
+@contextlib.contextmanager
+def local_imports():
+    try:
+        import __bubble__
+    except ImportError:
+        # We do not want to prevent some code to run both locally and remotely
+        yield
+    else:
+        # Add the site-packages directories to sys.path
+        for path in __bubble__.SITE_PACKAGES:
+            if path not in sys.path:
+                sys.path.append(path)
+
+        # Keep the old state in order to cover recursive calls to local_imports
+        old = __bubble__.local_imports
+        __bubble__.local_imports = True
+        try:
+            yield
+        finally:
+            __bubble__.local_imports = old
+            if not __bubble__.local_imports:
+                # Remove the site-packages directories from sys.path
+                for path in __bubble__.SITE_PACKAGES:
+                    if path in sys.path:
+                        sys.path.remove(path)
 
 
 def start_errloop():

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -519,6 +519,7 @@ class PipeTunnel(BaseTunnel):
             path=path,
             depthlimit=chopsticks.DEPTH_LIMIT,
             log_config=log_config,
+            allow_site_imports=SubprocessTunnel._allow_site_imports(),
         )
 
         self.errreader = ioloop.StderrReader(errloop, self.epipe, self.host)
@@ -574,7 +575,7 @@ class SubprocessTunnel(PipeTunnel):
 
     #: These arguments are used for bootstrapping Python into out remote agent
     PYTHON_ARGS = [
-        '-usS',
+        '-u',
         '-c',
         'import sys, os; _bsz = %d ;' % len(bubble) +
         'inpipe = os.fdopen(os.dup(0), \'rb\', _bsz); ' +
@@ -601,9 +602,20 @@ class SubprocessTunnel(PipeTunnel):
         self.rpipe = self.proc.stdout
         self.epipe = self.proc.stderr
 
+    @staticmethod
+    def _allow_site_imports():
+        if os.environ.get('CHOPSTICKS_ALLOW_SITE_IMPORTS') == '1':
+            return True
+        if getattr(sys, '_chopsticks_allow_site_imports', False):
+            return True
+        return getattr(chopsticks, 'allow_site_imports', False)
+
     def cmd_args(self):
         python = self.python2 if PY2 else self.python3
-        return [python] + self.PYTHON_ARGS
+        args = self.PYTHON_ARGS.copy()
+        if not self._allow_site_imports():
+            args.insert(0, '-sS')
+        return [python] + args
 
 
 class Local(SubprocessTunnel):

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import base64
 import logging
 import contextlib
 import subprocess
@@ -113,13 +114,16 @@ class DepthLimitExceeded(Exception):
 
 # Load/construct the bubble code
 try:
-    # If this is the remote side, we have the bubble code in __main__.__bubble
     bubble = sys.modules['__main__'].__bubble
 except (AttributeError, KeyError):
     pencode_bubble = pkgutil.get_data('chopsticks', 'pencode.py')
     bubble = pkgutil.get_data('chopsticks', 'bubble.py')
     bubble = bubble.replace(b'{{ PENCODE }}', pencode_bubble)
     del pencode_bubble
+
+# Base64-encode the bubble for safe transmission over text-mode stdin.
+# This avoids UnicodeDecodeError on remotes regardless of bubble content.
+bubble_b64 = base64.b64encode(bubble)
 
 
 class BaseTunnel(SetOps):
@@ -530,7 +534,7 @@ class PipeTunnel(BaseTunnel):
         self.callbacks[0] = wrapped_callback
 
         self.reader.start()
-        self.writer.write_raw(bubble)
+        self.writer.write_raw(bubble_b64)
 
         log_config = None
         if logging.root.handlers:
@@ -605,9 +609,9 @@ class SubprocessTunnel(PipeTunnel):
     PYTHON_ARGS = [
         '-u',
         '-c',
-        'import sys, os; _bsz = %d ;' % len(bubble) +
+        'import sys, os, base64; _bsz = %d ;' % len(bubble_b64) +
         'inpipe = os.fdopen(os.dup(0), \'rb\', _bsz); ' +
-        '__bubble = sys.stdin.read(_bsz); ' +
+        '__bubble = base64.b64decode(sys.stdin.read(_bsz)); ' +
         'exec(compile(__bubble, \'bubble.py\', \'exec\'))'
     ]
 

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -825,17 +825,20 @@ class SSHTunnel(SubprocessTunnel):
                  not ``ssh`` directly as the root user.
 
     """
-    def __init__(self, host, user=None, port=None, sudo=False, host_check=True, forward_agent=True):
+    def __init__(self, host, user=None, port=None, sudo=False, host_check=True, forward_agent=True, connect_timeout=10):
         self.host = host
         self.user = user
         self.port = port
         self.sudo = sudo
         self.host_check = host_check
         self.forward_agent = forward_agent
+        self.connect_timeout = connect_timeout
         super(SubprocessTunnel, self).__init__()
 
     def cmd_args(self):
         args = ['ssh', '-o', 'PasswordAuthentication=no']
+        if self.connect_timeout:
+            args += ['-o', 'ConnectTimeout=%d' % self.connect_timeout]
         if self.forward_agent:
             args.append('-A')
         if not self.host_check:

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -267,6 +267,45 @@ class BaseTunnel(SetOps):
                         source=self._read_source(path)
                     )
                     return
+        # Fallback: use importlib to locate modules not directly findable
+        # via sys.path traversal (e.g. modern editable installs that register
+        # via .pth / importlib.metadata without adding the source dir to sys.path).
+        try:
+            import importlib.util as _ilu
+            import os.path as _op
+            _spec = _ilu.find_spec(mod)
+            if _spec and _spec.origin and not _spec.origin.endswith(('.so', '.pyd')):
+                if fname:
+                    # Package data file (e.g. pkgutil.get_data): locate it
+                    # next to the package directory found via importlib.
+                    _pkg_dir = (list(_spec.submodule_search_locations)[0]
+                                if _spec.submodule_search_locations
+                                else _op.dirname(_spec.origin))
+                    _data_path = _op.join(_pkg_dir, fname)
+                    if _op.exists(_data_path):
+                        self.write_msg(
+                            OP_IMP, 0,
+                            mod=key,
+                            exists=True,
+                            is_pkg=False,
+                            file=stem + '/' + fname,
+                            source=self._read_source(_data_path)
+                        )
+                        return
+                else:
+                    _is_pkg = bool(_spec.submodule_search_locations)
+                    _rel = stem + ('/__init__.py' if _is_pkg else '.py')
+                    self.write_msg(
+                        OP_IMP, 0,
+                        mod=key,
+                        exists=True,
+                        is_pkg=_is_pkg,
+                        file=_rel,
+                        source=self._read_source(_spec.origin)
+                    )
+                    return
+        except Exception:
+            pass
         self.write_msg(
             OP_IMP,
             0,

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -843,7 +843,7 @@ class SSHTunnel(SubprocessTunnel):
         if self.user:
             args.extend(['-l', self.user])
         if self.port:
-            args.extend(['-p', self.port])
+            args.extend(['-p', str(self.port)])
         args.append(self.host)
         if self.sudo:
             args.append('sudo')

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import logging
 import subprocess
 import sys
 import os
@@ -503,12 +504,21 @@ class PipeTunnel(BaseTunnel):
         self.reader.start()
         self.writer.write_raw(bubble)
 
+        log_config = None
+        if logging.root.handlers:
+            log_config = dict(
+                format=logging.root.handlers[0].formatter._fmt,
+                datefmt=logging.root.handlers[0].formatter.datefmt,
+                level=min(logging.root.level, logging.INFO),
+            )
+
         self.write_msg(
             OP_START,
             req_id=0,
             host=self.host,
             path=path,
             depthlimit=chopsticks.DEPTH_LIMIT,
+            log_config=log_config,
         )
 
         self.errreader = ioloop.StderrReader(errloop, self.epipe, self.host)

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -825,15 +825,21 @@ class SSHTunnel(SubprocessTunnel):
                  not ``ssh`` directly as the root user.
 
     """
-    def __init__(self, host, user=None, port=None, sudo=False):
+    def __init__(self, host, user=None, port=None, sudo=False, host_check=True, forward_agent=True):
         self.host = host
         self.user = user
         self.port = port
         self.sudo = sudo
+        self.host_check = host_check
+        self.forward_agent = forward_agent
         super(SubprocessTunnel, self).__init__()
 
     def cmd_args(self):
         args = ['ssh', '-o', 'PasswordAuthentication=no']
+        if self.forward_agent:
+            args.append('-A')
+        if not self.host_check:
+            args += ['-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no']
         if self.user:
             args.extend(['-l', self.user])
         if self.port:

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -633,6 +633,94 @@ class Sudo(SubprocessTunnel):
         self.proc.wait()
 
 
+class NSpawn(SubprocessTunnel):
+    """A tunnel to a process on the same host, launched with nspawn.
+
+    Args:
+        directory (string):  directory of the machine image
+    """
+
+    def __init__(self, directory, machine=None):
+        self.directory = directory
+        self.machine = machine
+        self.host = machine or directory
+        super(NSpawn, self).__init__()
+
+    def cmd_args(self):
+        args = []
+        uid = os.getuid()
+        if uid != 0:
+            args += ['sudo', '--non-interactive']
+        args += ['systemd-nspawn', '--directory', self.directory]
+        if self.machine:
+            args += ['--machine', self.machine]
+        args += super(NSpawn, self).cmd_args()
+        return args
+
+    def close(self):
+        self.wpipe.close()
+        self.proc.wait()
+
+
+class NSEnter(SubprocessTunnel):
+    """A tunnel to a process on the same host, launched with nsenter.
+
+    This is a generic tunnel for all containers using linux namespaces
+    such as docker, systemd-nspawn, rkt, ... that can be spawned as a
+    subprocess of any given process id. This tunnel uses sudo hence it
+    requires the same passworless setup than the Sudo tunnel plus the
+    ``nsenter`` command line utility found in ``linux-utils`` package.
+
+
+    Args:
+        pid (int):  the process id that will be used as parent process for the
+            python interpreter
+
+    Kwargs:
+        keep_environ (bool): specify if the caller's environment should be kept
+
+        namespaces (list): optional list of namespaces to enter, valid
+            namespaces are: 'mount', 'uts', 'ipc', 'net', 'pid'
+            Defautls to all namespaces.
+    """
+
+    def __init__(self, pid, keep_environ=False, namespaces=None):
+        self.pid = int(pid)
+        self.host = 'PID#%s@localhost' % self.pid
+        self.keep_environ = keep_environ
+        valid_namespaces = set(('mount', 'uts', 'ipc', 'net', 'pid'))
+        if namespaces and not set(namespaces).issubset(valid_namespaces):
+            raise ValueError("Invalid namespace %s" %
+                             (namespaces - valid_namespaces))
+        self.namespaces = namespaces or valid_namespaces
+        super(NSEnter, self).__init__()
+
+    def cmd_args(self):
+        uid = os.getuid()
+        gid = os.getegid()
+        args = []
+        if uid != 0:
+            args += ['sudo', '--non-interactive']
+        args += ['nsenter', '-t', str(self.pid)]
+        args += ['--%s' % name for name in self.namespaces]
+        args += ['-S', str(uid), '-G', str(gid)]
+        if not self.keep_environ:
+            env = self.get_environ()
+            args += ['--', 'env', '-i', '-'] + env
+        else:
+            args.append('--')
+        args += super(NSEnter, self).cmd_args()
+        return args
+
+    def get_environ(self):
+        with open('/proc/%d/environ' % self.pid, 'r') as f:
+            return [var for var in f.read().split('\x00') if var.strip()]
+
+    def close(self):
+        self.wpipe.close()
+        self.proc.wait()
+
+
 class Docker(SubprocessTunnel):
     """A tunnel connected to a throwaway Docker container.
 

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -897,7 +897,8 @@ class SSHTunnel(SubprocessTunnel):
                  not ``ssh`` directly as the root user.
 
     """
-    def __init__(self, host, user=None, port=None, sudo=False, host_check=True, forward_agent=True, connect_timeout=10):
+    def __init__(self, host, user=None, port=None, sudo=False, host_check=True,
+                 forward_agent=True, connect_timeout=10, keep_alive=10):
         self.host = host
         self.user = user
         self.port = port
@@ -905,12 +906,16 @@ class SSHTunnel(SubprocessTunnel):
         self.host_check = host_check
         self.forward_agent = forward_agent
         self.connect_timeout = connect_timeout
+        self.keep_alive = keep_alive
         super(SubprocessTunnel, self).__init__()
 
     def cmd_args(self):
         args = ['ssh', '-o', 'PasswordAuthentication=no']
         if self.connect_timeout:
             args += ['-o', 'ConnectTimeout=%d' % self.connect_timeout]
+        if self.keep_alive:
+            args += ['-o', 'ServerAliveInterval=%d' % self.keep_alive,
+                     '-o', 'ServerAliveCountMax=6']
         if self.forward_agent:
             args.append('-A')
         if not self.host_check:

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -29,7 +29,30 @@ else:
 __metaclass__ = type
 
 # One global loop for all tunnels
-loop = ioloop.IOLoop()
+_loop_local = threading.local()
+
+
+class _ThreadLocalLoopProxy:
+    """Proxy that gives each thread its own IOLoop instance.
+
+    concurrent tunnel.call() from multiple threads must not share a single
+    IOLoop: the loop is not re-entrant and would deadlock when two threads
+    both try to run it at once.  Making it thread-local means each worker
+    thread drives its own loop independently.
+    """
+    def _get(self):
+        if not hasattr(_loop_local, 'loop'):
+            _loop_local.loop = ioloop.IOLoop()
+        return _loop_local.loop
+
+    def __getattr__(self, name):
+        return getattr(self._get(), name)
+
+    def __setattr__(self, name, value):
+        setattr(self._get(), name, value)
+
+
+loop = _ThreadLocalLoopProxy()
 
 # Another thread will output stderr
 errloop = ioloop.IOLoop()

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -678,8 +678,8 @@ class SubprocessTunnel(PipeTunnel):
         '-u',
         '-c',
         'import sys, os, base64; _bsz = %d ;' % len(bubble_b64) +
-        'inpipe = os.fdopen(os.dup(0), \'rb\', _bsz); ' +
-        '__bubble = base64.b64decode(sys.stdin.read(_bsz)); ' +
+        'inpipe = os.fdopen(os.dup(0), \'rb\', 8192); ' +
+        '__bubble = base64.b64decode(inpipe.read(_bsz)); ' +
         'exec(compile(__bubble, \'bubble.py\', \'exec\'))'
     ]
 

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -565,6 +565,10 @@ class PipeTunnel(BaseTunnel):
 
     """
 
+    def __init__(self):
+        self.errreader = None
+        super().__init__()
+
     def _connect_async(self, callback):
         if self.connected:
             callback(None)
@@ -635,6 +639,8 @@ class PipeTunnel(BaseTunnel):
     def close(self):
         if not self.connected:
             return
+        if self.errreader:
+            self.errreader.stop()
         self.wpipe.close()  # Terminate child
         self.reader.stop()
         self.writer.stop()

--- a/doc/tunnels.rst
+++ b/doc/tunnels.rst
@@ -31,6 +31,18 @@ Docker
 .. autoclass:: Docker
 
 
+NSpawn
+''''''
+
+.. autoclass:: NSpawn
+
+
+NSenter
+''''''
+
+.. autoclass:: NSenter
+
+
 Subprocess
 ''''''''''
 

--- a/test_chopsticks.py
+++ b/test_chopsticks.py
@@ -4,6 +4,15 @@ from chopsticks.tunnel import Tunnel, Local
 from chopsticks.facts import ip, python_version
 import time
 
+def decorator(fn):
+    return fn
+
+
+@decorator
+def decorated():
+    return 'ok'
+
+
 hosts = [
     Tunnel('byzantium'),
 #    Tunnel('office'),
@@ -13,4 +22,5 @@ for t in hosts:
     print('Time on %s:' % t.host, t.call(time.time))
     print('%s ip:' % t.host, t.call(ip))
     print('%s Python version: %s' % (t.host, t.call(python_version)))
+    print('Decorated call status: %s' % t.call(decorated))
     print()


### PR DESCRIPTION
NSEnter: A tunnel to a process on the same host, launched with nsenter.

This is a generic tunnel for all containers using linux namespaces such as docker, systemd-nspawn, rkt, ... that can be spawned as a subprocess of any given process id. This tunnel uses sudo hence it
requires the same passworless setup than the `Sudo` tunnel plus the ``nsenter`` command line utility found in ``linux-utils`` package.
