### PR TITLE
Fix bug preventing decorated functions to be called remotely (Fixes #50)

### DIFF
--- a/chopsticks/serialise_main.py
+++ b/chopsticks/serialise_main.py
@@ -103,7 +103,7 @@ def serialise_func(f, seen=()):
             else:
                 subdeps = serialise_func(v, seen=seen + (f, v,))
                 vsource, _, _, vnames, vvars = subdeps
-                source += '\n\n' + vsource
+                source = vsource + '\n\n' + source
                 imported_names.update(vnames)
                 variables.update(vvars)
         else:


### PR DESCRIPTION
My patch is quite naive (prepending instead of appending) and I'm not 100% sure that I don't break something while trying to fix this. Could you have a look ?

Thanks.