### PR TITLE
Fix buffering issue with python3 and slow hosts (Fixes #52)

### DIFF
--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -10,9 +10,8 @@ def debug(msg):
 
 # Reshuffle fds so that we can't break our transport by printing to stdout
 import os
-infd = os.dup(0)
+# inpipe is defined in the bootstrap command line code in tunnel.py
 outfd = os.dup(1)
-inpipe = os.fdopen(infd, 'rb')
 outpipe = os.fdopen(outfd, 'wb', 0)
 sys.stdin.close()
 sys.stdin = open(os.devnull, 'r')

--- a/chopsticks/tunnel.py
+++ b/chopsticks/tunnel.py
@@ -562,9 +562,12 @@ class SubprocessTunnel(PipeTunnel):
     PYTHON_ARGS = [
         '-usS',
         '-c',
-        'import sys, os; sys.stdin = os.fdopen(0, \'rb\', 0); ' +
-        '__bubble = sys.stdin.read(%d); ' % len(bubble) +
-        'exec(compile(__bubble, \'bubble.py\', \'exec\'))'
+        (
+            'import sys, os; '
+            'inpipe = os.fdopen(os.dup(0), \'rb\'); '
+            '__bubble = inpipe.read(%d); '
+            'exec(compile(__bubble, \'bubble.py\', \'exec\'))'
+        ) % (len(bubble), )
     ]
 
     # Paths to the Python 2/3 binary on the remote host


### PR DESCRIPTION
It looks as though the change in Python 3 is that an unbuffered file
object opened with fdopen no longer returns exactly size bytes - instead
it focuses on only doing one system call.

This patch will prevent to read the stdin first, then reopening the file
afterward in bubble.py, instead we dup the file in the bootstrap code
and we use the same file descriptor in bubble.py hence we don't need
to use an unbuffered stdin anymore.