### PR TITLE
Add `local_imports` context manager (allow to disable tunnelled imports)

### DIFF
--- a/chopsticks/bubble.py
+++ b/chopsticks/bubble.py
@@ -53,6 +53,7 @@ import traceback
 from base64 import b64decode
 import tempfile
 import codecs
+import site
 
 
 outqueue = Queue(maxsize=10)
@@ -60,9 +61,11 @@ tasks = Queue()
 done = object()
 
 running = True
+local_imports = False
 
 Imp = namedtuple('Imp', 'exists is_pkg file source')
 PREFIX = 'chopsticks://'
+SITE_PACKAGES = site.getsitepackages() + [site.getusersitepackages()]
 
 
 class Loader:
@@ -118,6 +121,10 @@ class Loader:
         return imp
 
     def find_module(self, fullname, path=None):
+        global local_imports
+        if local_imports:
+            return None
+
         try:
             self.get(fullname)
         except ImportError:


### PR DESCRIPTION
Example:

    def remote_function():
        with chopsticks.tunnel.local_imports():
            import psycopg2
        ...

@lordmauve I admit the name `local_imports` is not right. Technically, using it make the remote machine use local imports (relative to itself). But when the developer is reasoning about chopsticks code, one might argue that he wants to use the remote imports (relative to it's workstation), hence might find `remote_imports` more relevant. This make me think we should use a completely different name.

If you're not against this patch, may I ask you some guidance about a good name to use for this context manager, then I'll update my branch. Thanks!