### PR TITLE
Optimisation: Don't pencode() singletons as back references

### DIFF
--- a/benchmark_pencode.py
+++ b/benchmark_pencode.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+import perf
+
+from chopsticks.pencode import pencode, pdecode
+
+
+def setup():
+    return [[
+        1000+i,
+        str(1000+i),
+        42,
+        42.0,
+        10121071034790721094712093712037123,
+        None,
+        True,
+        b'qwertyuiop',
+        u'qwertyuiop',
+        ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+        ('q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'),
+        {'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'},
+        frozenset(['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p']),
+        {'e': 101, 'i': 105, 'o': 111, 'q': 113, 'p': 112,
+         'r': 114, 'u': 117, 't': 116, 'w': 119, 'y': 121},
+        ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', i],
+        ('q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', i),
+        {'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', i},
+        frozenset(['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', i]),
+        {'e': 101, 'i': 105, 'o': 111, 'q': 113, 'p': 112,
+         'r': 114, 'u': 117, 't': 116, 'w': 119, 'y': 121, 'x': i},
+    ] for i in range(1000)]
+
+runner = perf.Runner()
+
+
+if __name__ == '__main__':
+    v = setup()
+    assert pdecode(pencode(v)) == v
+    #pencode(v)
+    runner.timeit(
+        name='pencode',
+        stmt='pencode(v)',
+        globals={'v': v, 'pencode': pencode},
+    )

--- a/chopsticks/pencode.py
+++ b/chopsticks/pencode.py
@@ -65,7 +65,6 @@ CODE_SEQTYPES = dict((v, k) for k, v in SEQTYPE_CODES.items())
 class Pencoder(object):
     def __init__(self):
         self.out = []
-        self.objs = 0
         self.backrefs = {}
 
     def getvalue(self):

--- a/chopsticks/pencode.py
+++ b/chopsticks/pencode.py
@@ -10,6 +10,7 @@ import struct
 import codecs
 
 SZ = struct.Struct('!I')
+REF = struct.Struct('!cI')
 
 utf8_decode = codecs.getdecoder('utf8')
 
@@ -75,10 +76,10 @@ class Pencoder(object):
         out = self.out
         objid = id(obj)
         if objid in self.backrefs:
-            out.extend([b'R', SZ.pack(self.backrefs[objid])])
+            out.append(self.backrefs[objid])
             return
         else:
-            self.backrefs[objid] = len(self.backrefs)
+            self.backrefs[objid] = REF.pack(b'R', len(self.backrefs))
 
         otype = type(obj)
 

--- a/chopsticks/pencode.py
+++ b/chopsticks/pencode.py
@@ -99,7 +99,7 @@ class Pencoder(object):
             bs = str(int(obj)).encode('ascii')
             out.extend([b'i', bsz(bs), bs])
         elif isinstance(obj, float):
-            bs = str(float(obj)).encode('ascii')
+            bs = repr(float(obj)).encode('ascii')
             out.extend([b'f', bsz(bs), bs])
         elif otype in SEQTYPE_CODES:
             code = SEQTYPE_CODES[otype]

--- a/chopsticks/pencode.py
+++ b/chopsticks/pencode.py
@@ -74,14 +74,6 @@ class Pencoder(object):
     def _pencode(self, obj):
         """Inner function for encoding of structures."""
         out = self.out
-        if obj is None:
-            out.append(b'n')
-            return
-
-        if isinstance(obj, bool):
-            out.append(b'T' if obj else b'F')
-            return
-
         objid = id(obj)
         if objid in self.backrefs:
             out.extend([b'R', SZ.pack(self.backrefs[objid])])
@@ -101,6 +93,8 @@ class Pencoder(object):
         elif isinstance(obj, unicode):
             bs = obj.encode('utf8')
             out.extend([b's', bsz(bs), bs])
+        elif isinstance(obj, bool):
+            out.extend([b'1', b't' if obj else b'f'])
         elif isinstance(obj, (int, long)):
             bs = str(int(obj)).encode('ascii')
             out.extend([b'i', bsz(bs), bs])
@@ -117,6 +111,8 @@ class Pencoder(object):
             for k in obj:
                 self._pencode(k)
                 self._pencode(obj[k])
+        elif obj is None:
+            out.append(b'n')
         else:
             raise ValueError('Unserialisable type %s' % type(obj))
 
@@ -169,10 +165,8 @@ class PDecoder(object):
             obj = obuf.read_bytes(sz)
             if not PY2:
                 obj = obj.decode('ascii')
-        elif code == b'F':
-            obj = False
-        elif code == b'T':
-            obj = True
+        elif code == b'1':
+            obj = obuf.read_bytes(1) == b't'
         elif code == b'i':
             sz = obuf.read_size()
             obj = int(obuf.read_bytes(sz))

--- a/chopsticks/pencode.py
+++ b/chopsticks/pencode.py
@@ -148,10 +148,15 @@ class PDecoder(object):
         return self._decode(obuf(buf))
 
     def _decode(self, obuf):
+        code = obuf.read_bytes(1)
+        if code == b'R':
+            ref_id = obuf.read_size()
+            obj = self.backrefs[ref_id]
+            return obj
+
         br_id = self.br_count
         self.br_count += 1
 
-        code = obuf.read_bytes(1)
         if code == b'n':
             obj = None
         elif code == b'b':
@@ -195,9 +200,6 @@ class PDecoder(object):
                 key = self._decode(obuf)
                 value = self._decode(obuf)
                 obj[key] = value
-        elif code == b'R':
-            ref_id = obuf.read_size()
-            obj = self.backrefs[ref_id]
         else:
             raise ValueError('Unknown pack opcode %r' % code)
 

--- a/tests/test_pencode.py
+++ b/tests/test_pencode.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for Python-friendly binary encoding."""
+import math
+
 from hypothesis import example, given, strategies
 import pytest
 from chopsticks.pencode import pencode, pdecode
@@ -53,6 +55,12 @@ def assert_roundtrip(obj):
     assert isinstance(buf, bytes)
     obj2 = pdecode(buf)
 
+    assert type(obj) == type(obj2)
+
+    # By definition NaN does not equal anything, even itself
+    if isinstance(obj2, float) and math.isnan(obj2):
+        return obj2
+
     try:
         assert obj == obj2
     except RuntimeError as e:
@@ -63,7 +71,6 @@ def assert_roundtrip(obj):
     except RecursionError:
         pass
 
-    assert type(obj) == type(obj2)
     return obj2
 
 

--- a/tests/test_pencode.py
+++ b/tests/test_pencode.py
@@ -4,6 +4,13 @@ from hypothesis import example, given, strategies
 import pytest
 from chopsticks.pencode import pencode, pdecode
 
+try:
+    # Added in Python 3.5+
+    RecursionError
+except NameError:
+    class RecursionError(RuntimeError):
+        pass
+
 bytes = type(b'')
 
 def is_ascii(s):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = py27,py33,py34,py35,py36
 
 [testenv]
-deps=pytest
+deps=
+    hypothesis
+    pytest
 commands=py.test
 
 [flake8]


### PR DESCRIPTION
This commit reduces the encoded size of repeated None values (from 5
bytes to 1 byte) and any bool value(from 5 bytes to 1 byte). To achieve
this
- None, False & True are encoded before backref checking is performed
- the wire format is modified, to encode bool values in the type code.

```
$ python -c"import chopsticks.pencode; print len(chopsticks.pencode.pencode([None]*100))"
501
$ python -c"import chopsticks.pencode; print len(chopsticks.pencode.pencode([True]*100))"
502
```

```
$ python -c"import chopsticks.pencode; print len(chopsticks.pencode.pencode([None]*100))"
105
$ python -c"import chopsticks.pencode; print len(chopsticks.pencode.pencode([True]*100))"
105
```